### PR TITLE
15 support tmux installed in non standard location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dotfiles/.host_setup.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,4 +65,4 @@ repos:
   - id: shellcheck
     # Zsh is not supported in shellcheck
     # Recommend removing shebang temporarily to lint, then restore
-    exclude: dotfiles/.zshrc
+    exclude: "dotfiles/.zshrc|dotfiles/.zprofile"

--- a/dotfiles/.aliases.sh
+++ b/dotfiles/.aliases.sh
@@ -7,6 +7,6 @@ alias glf='git reset --hard origin/$(git rev-parse --abbrev-ref HEAD)'
 alias gpu='git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)'
 
 # Custom Docker aliases
-alias drrieb="docker run --rm -it entrypoint bash"
+alias drrieb="docker run --rm -it --entrypoint bash"
 alias drri="docker run --rm -it"
 alias drr="docker run --rm"

--- a/dotfiles/.aliases.sh
+++ b/dotfiles/.aliases.sh
@@ -3,6 +3,7 @@
 # Custom git aliases
 alias gl="git pull"
 alias gri="git rebase -i"
+alias gdo='git diff origin/$(git rev-parse --abbrev-ref HEAD)'
 alias glf='git reset --hard origin/$(git rev-parse --abbrev-ref HEAD)'
 alias gpu='git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)'
 

--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -15,6 +15,9 @@ fi
 if [ -z ${TMUX+x} ]; then
   # If tmux is available, switch to it
   TMUX_EXECUTABLE_PATH=/bin/tmux
+  if which tmux; then
+    TMUX_EXECUTABLE_PATH=$(which tmux)
+  fi
   if [ -f "$TMUX_EXECUTABLE_PATH" ]; then
     export TARGET_SHELL
     exec "$TMUX_EXECUTABLE_PATH"

--- a/dotfiles/.shell_common.sh
+++ b/dotfiles/.shell_common.sh
@@ -2,6 +2,13 @@
 
 # Shell configuration agnostic of the shell tool
 
+# Perform host-specific setup, such as secrets that may not be checked into the repository
+HOST_SETUP_SCRIPT=$HOME/.host_setup.sh
+if [ -f "$HOST_SETUP_SCRIPT" ]; then
+  # shellcheck source=/dev/null
+  source "$HOST_SETUP_SCRIPT"
+fi
+
 export GHCR_USERNAME=rcwbr
 # shellcheck source=dotfiles/.aliases.sh
 source "$HOME/.aliases.sh"

--- a/dotfiles/.zprofile
+++ b/dotfiles/.zprofile
@@ -1,0 +1,1 @@
+source ~/.bashrc

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -9,8 +9,10 @@ export ZSH="$HOME/.oh-my-zsh"
 # shellcheck disable=SC2034
 plugins=(autojump docker fzf git pre-commit pyenv ssh thefuck tmux)
 
-# shellcheck source=/dev/null
-. /usr/share/autojump/autojump.zsh
+if [[ "$AUTOJUMP_SOURCED" != "1" ]]; then
+  # shellcheck source=/dev/null
+  . /usr/share/autojump/autojump.zsh
+fi
 
 # shellcheck disable=SC2034
 ZSH_THEME="re5et"


### PR DESCRIPTION
Closes #15 

> ## What
> 
> Check for tmux installation on system before establishing the executable path.
> 
> ## Why
> 
> In environments where the tmux executable is not installed in `/bin`.
> 
> ## How
> 
> Using `which` to adjust the executable path var.