### PR TITLE
fix: docker alias workdir mount substitution

### DIFF
--- a/dotfiles/.aliases.sh
+++ b/dotfiles/.aliases.sh
@@ -11,14 +11,22 @@ alias glf='git reset --hard origin/$(git rev-parse --abbrev-ref HEAD)'
 alias gpu='git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)'
 
 # shellcheck disable=SC2016
-WORKING_DIR_MOUNT='-v ${PWD}:${PWD} -w ${PWD}'
+WORKING_DIR_MOUNT='-v $(pwd):$(pwd) -w $(pwd)'
 
 # Custom Docker aliases
-alias drrieb='docker run --rm -it --entrypoint bash'
-alias drriebw='docker run --rm -it ${WORKING_DIR_MOUNT} --entrypoint bash'
-alias drrie='docker run --rm -it --entrypoint '
-alias drriew='docker run --rm -it ${WORKING_DIR_MOUNT} --entrypoint '
-alias drri='docker run --rm -it'
-alias drriw='docker run --rm -it ${WORKING_DIR_MOUNT}'
-alias drr='docker run --rm'
-alias drrw='docker run --rm ${WORKING_DIR_MOUNT}'
+
+alias drrieb="docker run --rm -it --entrypoint bash"
+# shellcheck disable=SC2139
+alias drriebw="docker run --rm -it ${WORKING_DIR_MOUNT} --entrypoint bash"
+
+alias drrie="docker run --rm -it --entrypoint "
+# shellcheck disable=SC2139
+alias drriew="docker run --rm -it ${WORKING_DIR_MOUNT} --entrypoint "
+
+alias drri="docker run --rm -it"
+# shellcheck disable=SC2139
+alias drriw="docker run --rm -it ${WORKING_DIR_MOUNT}"
+
+alias drr="docker run --rm"
+# shellcheck disable=SC2139
+alias drrw="docker run --rm ${WORKING_DIR_MOUNT}"


### PR DESCRIPTION
Closes #21 

> ## Expected behavior
> 
> `docker run` aliases with workdir mounting (e.g. `drriebw`) should successfully mount the working directory.
> 
> ## Observed behavior
> 
> Error:
> 
> ```bash
> docker: Error response from daemon: invalid volume specification: ' ${PWD}:${PWD} -w ${PWD}': invalid mount config for type "volume": invalid mount path: '${PWD} -w ${PWD}' mount path must be absolute.
> ```
> 
> ## Proposed resolution
> 
> Alter substitution to avoid treating args as a volume mount spec.
> 
