### PR TITLE
34 add alias for no-verify Git rebase

### DIFF
--- a/dotfiles/.aliases.sh
+++ b/dotfiles/.aliases.sh
@@ -6,6 +6,7 @@ alias gkl="git clean -fd"
 alias gkld="git clean -n -fd"
 alias gl="git pull"
 alias gri="git rebase -i"
+alias grin="git -c core.hooksPath=/dev/null rebase -i --ignore-date"
 alias gdo='git diff origin/$(git rev-parse --abbrev-ref HEAD)'
 alias glf='git reset --hard origin/$(git rev-parse --abbrev-ref HEAD)'
 alias gpu='git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)'

--- a/dotfiles/.vscode_extensions
+++ b/dotfiles/.vscode_extensions
@@ -1,3 +1,2 @@
-anthropic.claude-code
 eamodio.gitlens
 eliostruyf.vscode-remote-control


### PR DESCRIPTION
Closes #34 

> ## What
> 
> Add an alias for Git rebase without running hooks.
> 
> ## Why
> 
> Rebasing --no-verify committed change before correcting hook errors.
> 
> ## How
> 
> New alias in aliases.sh
> 